### PR TITLE
add line break white space

### DIFF
--- a/poems/canyon-secret-grin.qmd
+++ b/poems/canyon-secret-grin.qmd
@@ -10,22 +10,22 @@ categories:
   - poems
 ---
 
-High up in Devil's Canyon wall,
-A cheeky smile grins down at all—
-Red rock carved by wind and time,
+High up in Devil's Canyon wall,  
+A cheeky smile grins down at all—  
+Red rock carved by wind and time,  
 Playing nature's favorite rhyme.
 
-Green trees giggle from above,
-Junipers whisper tales of love,
-While hikers stop and point with glee:
+Green trees giggle from above,  
+Junipers whisper tales of love,  
+While hikers stop and point with glee:  
 "Look! The mountain's smiling at me!"
 
-This sandstone jester never frowns,
-Just grins at all the desert towns,
-A billion-year-old happy face
+This sandstone jester never frowns,  
+Just grins at all the desert towns,  
+A billion-year-old happy face  
 That makes Colorado such a place!
 
-So if you're walking Fruita's trails
-And need a laugh when courage fails,
-Just look up at that crimson wall—
+So if you're walking Fruita's trails  
+And need a laugh when courage fails,  
+Just look up at that crimson wall—  
 The canyon's smiling after all!

--- a/poems/red-rock-fury.qmd
+++ b/poems/red-rock-fury.qmd
@@ -10,17 +10,17 @@ categories:
   - poems
 ---
 
-The angry bird was on his perch,
-A sandstone fowl of flaming red.
-His beak so sharp, his eyes so mean,
+The angry bird was on his perch,  
+A sandstone fowl of flaming red.  
+His beak so sharp, his eyes so mean,  
 He'd scare your iPhone half to dead!
 
-No slingshot needed for this dude,
-He's permanently set to "RAGE"—
-The only bird who's been on tilt
+No slingshot needed for this dude,  
+He's permanently set to "RAGE"—  
+The only bird who's been on tilt  
 Since long before the Ice Age!
 
-Tourists point and laugh with glee,
-"Look, honey! He's from that phone game!"
-While geologists just roll their eyes:
+Tourists point and laugh with glee,  
+"Look, honey! He's from that phone game!"  
+While geologists just roll their eyes:  
 "It's erosion, folks—but sure, same same!"


### PR DESCRIPTION
this PR adds two spaces at the end of lines that are meant to be line breaks. With no extra spaces at then end of lines, quarto renders the markdown lines into a single paragraph, even though there are new lines.